### PR TITLE
Changed the waveform to a more pleasing gradient.

### DIFF
--- a/waveform-chrome.coffee
+++ b/waveform-chrome.coffee
@@ -1,5 +1,7 @@
 
-@Waveform = ({file, canvas, onStatus,onReady}) ->
+@waveformColor = {r: 195, g: 127, b: 63}
+
+@Waveform = ({file, canvas, onStatus, onReady}) ->
   canvas = $(canvas)
   status = $(status)
 
@@ -72,10 +74,10 @@
       h = val*50*height
 
       gradient = ctx.createLinearGradient(0,height/2-h/2,0,height/2+h/2)
-      gradient.addColorStop( 0, "rgba(195, 127, 63, 0)")
-      gradient.addColorStop(0.4, "rgba(195, 127, 63, 1)")
-      gradient.addColorStop(0.6, "rgba(195, 127, 63, 1)")
-      gradient.addColorStop(  1, "rgba(195, 127, 63, 0)")
+      gradient.addColorStop(0.0,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 0)")
+      gradient.addColorStop(0.4,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 1)")
+      gradient.addColorStop(0.6,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 1)")
+      gradient.addColorStop(1.0,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 0)")
       ctx.fillStyle = gradient
 
       ctx.fillRect(i,height/2-h/2,1,h)

--- a/waveform-chrome.coffee
+++ b/waveform-chrome.coffee
@@ -43,14 +43,14 @@
 @WaveformView = (canvas) ->
   {width,height} = canvas[0]
   ctx = canvas[0].getContext('2d')
-  ctx.fillStyle = 'black'
+  canvas[0].style.setProperty("background-color", "rgb(243, 205, 138)");
 
   cursor= $ """
     <div style="
       position: relative;
       height: #{height}px;
       width: 2px;
-      background-color: blue;">
+      background-color: #800;">
     """
 
   overlay = $ """
@@ -71,6 +71,14 @@
   self =
     drawBar: (i,val) ->
       h = val*50*height
+
+      gradient = ctx.createLinearGradient(0,height/2-h/2,0,height/2+h/2)
+      gradient.addColorStop( 0, "rgba(195, 127, 63, 0)")
+      gradient.addColorStop(0.4, "rgba(195, 127, 63, 1)")
+      gradient.addColorStop(0.6, "rgba(195, 127, 63, 1)")
+      gradient.addColorStop(  1, "rgba(195, 127, 63, 0)")
+      ctx.fillStyle = gradient
+
       ctx.fillRect(i,height/2-h/2,1,h)
     moveCursor: (pos) ->
       cursor.css 'left', pos*width

--- a/waveform-chrome.coffee
+++ b/waveform-chrome.coffee
@@ -1,14 +1,11 @@
-
-@waveformColor = {r: 195, g: 127, b: 63}
-
-@Waveform = ({file, canvas, onStatus, onReady}) ->
+@Waveform = ({file, canvas, waveformColor, onStatus, onReady}) ->
   canvas = $(canvas)
   status = $(status)
 
   sections = canvas.attr('width')
 
   self =
-    view: WaveformView canvas
+    view: WaveformView(canvas, waveformColor)
 
   req = new XMLHttpRequest()
   req.open 'GET', file, true
@@ -42,7 +39,7 @@
   self
 
 
-@WaveformView = (canvas) ->
+@WaveformView = (canvas, waveformColor) ->
   {width,height} = canvas[0]
   ctx = canvas[0].getContext('2d')
 
@@ -74,10 +71,10 @@
       h = val*50*height
 
       gradient = ctx.createLinearGradient(0,height/2-h/2,0,height/2+h/2)
-      gradient.addColorStop(0.0,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 0)")
-      gradient.addColorStop(0.4,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 1)")
-      gradient.addColorStop(0.6,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 1)")
-      gradient.addColorStop(1.0,"rgba("+@waveformColor.r+","+@waveformColor.g+","+@waveformColor.b+", 0)")
+      gradient.addColorStop(0.0,"rgba("+waveformColor.r+","+waveformColor.g+","+waveformColor.b+", 0)")
+      gradient.addColorStop(0.4,"rgba("+waveformColor.r+","+waveformColor.g+","+waveformColor.b+", 1)")
+      gradient.addColorStop(0.6,"rgba("+waveformColor.r+","+waveformColor.g+","+waveformColor.b+", 1)")
+      gradient.addColorStop(1.0,"rgba("+waveformColor.r+","+waveformColor.g+","+waveformColor.b+", 0)")
       ctx.fillStyle = gradient
 
       ctx.fillRect(i,height/2-h/2,1,h)

--- a/waveform-chrome.coffee
+++ b/waveform-chrome.coffee
@@ -43,7 +43,6 @@
 @WaveformView = (canvas) ->
   {width,height} = canvas[0]
   ctx = canvas[0].getContext('2d')
-  canvas[0].style.setProperty("background-color", "rgb(243, 205, 138)");
 
   cursor= $ """
     <div style="

--- a/waveform-chrome.js
+++ b/waveform-chrome.js
@@ -1,17 +1,12 @@
 (function() {
-  this.waveformColor = {
-    r: 195,
-    g: 127,
-    b: 63
-  };
   this.Waveform = function(_arg) {
-    var canvas, file, loadBuffer, onReady, onStatus, req, sections, self, status;
-    file = _arg.file, canvas = _arg.canvas, onStatus = _arg.onStatus, onReady = _arg.onReady;
+    var canvas, file, loadBuffer, onReady, onStatus, req, sections, self, status, waveformColor;
+    file = _arg.file, canvas = _arg.canvas, waveformColor = _arg.waveformColor, onStatus = _arg.onStatus, onReady = _arg.onReady;
     canvas = $(canvas);
     status = $(status);
     sections = canvas.attr('width');
     self = {
-      view: WaveformView(canvas)
+      view: WaveformView(canvas, waveformColor)
     };
     req = new XMLHttpRequest();
     req.open('GET', file, true);
@@ -37,7 +32,7 @@
     };
     return self;
   };
-  this.WaveformView = function(canvas) {
+  this.WaveformView = function(canvas, waveformColor) {
     var ctx, cursor, height, overlay, self, width, _ref;
     _ref = canvas[0], width = _ref.width, height = _ref.height;
     ctx = canvas[0].getContext('2d');
@@ -56,10 +51,10 @@
         var gradient, h;
         h = val * 50 * height;
         gradient = ctx.createLinearGradient(0, height / 2 - h / 2, 0, height / 2 + h / 2);
-        gradient.addColorStop(0.0, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 0)");
-        gradient.addColorStop(0.4, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 1)");
-        gradient.addColorStop(0.6, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 1)");
-        gradient.addColorStop(1.0, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 0)");
+        gradient.addColorStop(0.0, "rgba(" + waveformColor.r + "," + waveformColor.g + "," + waveformColor.b + ", 0)");
+        gradient.addColorStop(0.4, "rgba(" + waveformColor.r + "," + waveformColor.g + "," + waveformColor.b + ", 1)");
+        gradient.addColorStop(0.6, "rgba(" + waveformColor.r + "," + waveformColor.g + "," + waveformColor.b + ", 1)");
+        gradient.addColorStop(1.0, "rgba(" + waveformColor.r + "," + waveformColor.g + "," + waveformColor.b + ", 0)");
         ctx.fillStyle = gradient;
         return ctx.fillRect(i, height / 2 - h / 2, 1, h);
       },

--- a/waveform-chrome.js
+++ b/waveform-chrome.js
@@ -1,4 +1,4 @@
-
+(function() {
   this.Waveform = function(_arg) {
     var canvas, file, loadBuffer, onReady, onStatus, req, sections, self, status;
     file = _arg.file, canvas = _arg.canvas, onStatus = _arg.onStatus, onReady = _arg.onReady;
@@ -32,13 +32,12 @@
     };
     return self;
   };
-
   this.WaveformView = function(canvas) {
     var ctx, cursor, height, overlay, self, width, _ref;
     _ref = canvas[0], width = _ref.width, height = _ref.height;
     ctx = canvas[0].getContext('2d');
-    ctx.fillStyle = 'black';
-    cursor = $("<div style=\"\n  position: relative;\n  height: " + height + "px;\n  width: 2px;\n  background-color: blue;\">");
+    canvas[0].style.setProperty("background-color", "rgb(243, 205, 138)");
+    cursor = $("<div style=\"\n  position: relative;\n  height: " + height + "px;\n  width: 2px;\n  background-color: #800;\">");
     overlay = $("<div style=\"\n  position: relative;\n  top: -" + height + "px;\n  height: 0px;\">");
     overlay.append(cursor);
     canvas.after(overlay);
@@ -50,8 +49,14 @@
     });
     return self = {
       drawBar: function(i, val) {
-        var h;
+        var gradient, h;
         h = val * 50 * height;
+        gradient = ctx.createLinearGradient(0, height / 2 - h / 2, 0, height / 2 + h / 2);
+        gradient.addColorStop(0, "rgba(195, 127, 63, 0)");
+        gradient.addColorStop(0.4, "rgba(195, 127, 63, 1)");
+        gradient.addColorStop(0.6, "rgba(195, 127, 63, 1)");
+        gradient.addColorStop(1, "rgba(195, 127, 63, 0)");
+        ctx.fillStyle = gradient;
         return ctx.fillRect(i, height / 2 - h / 2, 1, h);
       },
       moveCursor: function(pos) {
@@ -59,7 +64,6 @@
       }
     };
   };
-
   this.PlayBuffer = function(audio, buffer) {
     var node, paused, self, start, timeBasis, timeStart;
     node = null;
@@ -101,7 +105,6 @@
       }
     };
   };
-
   this.ProcessAudio = {
     extract: function(buffer, sections, out, done) {
       var f, i, int, len;
@@ -117,10 +120,10 @@
           i++;
           if (i >= sections) {
             clearInterval(int);
-            if (typeof done === "function") done();
+            if (typeof done === "function") {
+              done();
+            }
             break;
-          } else {
-            _results.push(void 0);
           }
         }
         return _results;
@@ -137,3 +140,4 @@
       return Math.sqrt(sum / data.length);
     }
   };
+}).call(this);

--- a/waveform-chrome.js
+++ b/waveform-chrome.js
@@ -1,4 +1,9 @@
 (function() {
+  this.waveformColor = {
+    r: 195,
+    g: 127,
+    b: 63
+  };
   this.Waveform = function(_arg) {
     var canvas, file, loadBuffer, onReady, onStatus, req, sections, self, status;
     file = _arg.file, canvas = _arg.canvas, onStatus = _arg.onStatus, onReady = _arg.onReady;
@@ -51,10 +56,10 @@
         var gradient, h;
         h = val * 50 * height;
         gradient = ctx.createLinearGradient(0, height / 2 - h / 2, 0, height / 2 + h / 2);
-        gradient.addColorStop(0, "rgba(195, 127, 63, 0)");
-        gradient.addColorStop(0.4, "rgba(195, 127, 63, 1)");
-        gradient.addColorStop(0.6, "rgba(195, 127, 63, 1)");
-        gradient.addColorStop(1, "rgba(195, 127, 63, 0)");
+        gradient.addColorStop(0.0, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 0)");
+        gradient.addColorStop(0.4, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 1)");
+        gradient.addColorStop(0.6, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 1)");
+        gradient.addColorStop(1.0, "rgba(" + this.waveformColor.r + "," + this.waveformColor.g + "," + this.waveformColor.b + ", 0)");
         ctx.fillStyle = gradient;
         return ctx.fillRect(i, height / 2 - h / 2, 1, h);
       },

--- a/waveform-chrome.js
+++ b/waveform-chrome.js
@@ -36,7 +36,6 @@
     var ctx, cursor, height, overlay, self, width, _ref;
     _ref = canvas[0], width = _ref.width, height = _ref.height;
     ctx = canvas[0].getContext('2d');
-    canvas[0].style.setProperty("background-color", "rgb(243, 205, 138)");
     cursor = $("<div style=\"\n  position: relative;\n  height: " + height + "px;\n  width: 2px;\n  background-color: #800;\">");
     overlay = $("<div style=\"\n  position: relative;\n  top: -" + height + "px;\n  height: 0px;\">");
     overlay.append(cursor);

--- a/waveform.html
+++ b/waveform.html
@@ -6,7 +6,7 @@
 <div id="play"><button type="button">Play / Pause</div>
 
 <style>
-canvas { border: solid 1px black }
+canvas { border: solid 1px black; background: rgb(243, 205, 138); }
 </style>
 
 <script>

--- a/waveform.html
+++ b/waveform.html
@@ -10,10 +10,12 @@ canvas { border: solid 1px black; background: rgb(243, 205, 138); }
 </style>
 
 <script>
+
 $(function() {
   var sound = Waveform({
     file: 'src.ogg',
     canvas: $('#canvas'),
+    waveformColor: {r: 195, g: 127, b: 63},
     onStatus: function(x) {
       $('#status').text('Loading '+Math.floor(x*100)+'%')
     },


### PR DESCRIPTION
This reminds me of when I did the images for http://music.garron.us/hacks/ using https://github.com/lgarron/lgsound2png . It's hard to make them _really_ pretty, but a gradual fade at the end looks a lot nicer.

Here's an example:
http://www.garron.us/archive/img/2011/gun_io_waveform_recolored.png

Values are hardcoded to gun.io's example just for demonstration. Not sure how what the best way is to handle arbitrary RGB color inputs and use them in color stops with varying transparencies.

If you want to merge this, great. If not, I hope something like this gets added.

Anyhow, this project seems quite exciting. I was lamenting the lack of an easy way to do this just yesterday. :-P
